### PR TITLE
Fix checkbox multiselect always required

### DIFF
--- a/lib/widget/edit/CheckboxMultiselect.js
+++ b/lib/widget/edit/CheckboxMultiselect.js
@@ -9,6 +9,7 @@
 	// In case of the Forms, we are not interested in raw HTML element, so this can be skipped
 	mw.ext.forms.widget.edit.CheckboxMultiselect = function( cfg ) {
 		mw.ext.forms.widget.edit.CheckboxMultiselect.parent.call( this, cfg );
+		this.required = cfg.required || false;
 		if ( cfg.horizontal ) {
 			this.$element.addClass( 'widget-multioption-horizontal' );
 		}
@@ -45,7 +46,7 @@
 	mw.ext.forms.widget.edit.CheckboxMultiselect.prototype.getValidity = function() {
 		var dfd = $.Deferred();
 
-		if ( this.getValue().length === 0 ) {
+		if ( this.required && this.getValue().length === 0 ) {
 			dfd.reject();
 		} else {
 			dfd.resolve();


### PR DESCRIPTION
This widget was always treated as "required".

ERM ???